### PR TITLE
feat(cli): add interactive mode using inquire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,10 +78,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -108,6 +120,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -171,6 +189,7 @@ dependencies = [
  "clap",
  "etcetera",
  "glob",
+ "inquire",
  "ron",
  "serde",
  "serde_json",
@@ -179,6 +198,31 @@ dependencies = [
  "toml",
  "unescaper",
  "walkdir",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -192,6 +236,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "equivalent"
@@ -225,6 +275,24 @@ name = "fastrand"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "glob"
@@ -264,6 +332,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,16 +373,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "predicates"
@@ -345,6 +490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,7 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
  "unicode-ident",
@@ -369,7 +523,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -390,6 +544,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -444,6 +604,42 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "strsim"
@@ -502,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +757,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +800,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +829,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-ctl"
 description = "CLI for COSMIC Desktop configuration management"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Heitor Augusto <IAm.HeitorALN@proton.me>"]
 homepage = "https://github.com/cosmic-utils/cosmic-ctl"
 repository = "https://github.com/cosmic-utils/cosmic-ctl"
@@ -18,6 +18,7 @@ bracoxide = "0.1.4"
 clap = { version = "4.5.21", features = ["derive"] }
 etcetera = "0.8.0"
 glob = "0.3.1"
+inquire = "0.7.5"
 ron = "0.10.1"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-ext-ctl";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = lib.fileset.toSource {
     root = ./..;

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -17,10 +17,10 @@ use std::{
 #[derive(Args)]
 pub struct ApplyCommand {
     /// Path to the configuration file (supports JSON, TOML, RON).
-    file: PathBuf,
+    pub file: PathBuf,
     /// Print verbose output about skipped entries.
     #[arg(short, long)]
-    verbose: bool,
+    pub verbose: bool,
 }
 
 impl Command for ApplyCommand {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -16,16 +16,16 @@ use walkdir::WalkDir;
 #[derive(Args)]
 pub struct BackupCommand {
     /// Path to the output configuration file (supports JSON, TOML, RON).
-    file: PathBuf,
+    pub file: PathBuf,
     /// Show which entries are being backed up.
     #[arg(short, long)]
-    verbose: bool,
+    pub verbose: bool,
     /// The XDG directories to backup (comma-separated) (e.g., 'config,cache,data').
     #[arg(short, long, value_delimiter = ',', default_value = "config,state")]
-    xdg_dirs: Vec<String>,
+    pub xdg_dirs: Vec<String>,
     /// Output format (auto-detected from file extension if not specified).
     #[arg(short, long)]
-    format: Option<String>,
+    pub format: Option<String>,
 }
 
 impl Command for BackupCommand {

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -9,19 +9,19 @@ use std::{io::Error, path::PathBuf};
 pub struct DeleteCommand {
     /// The configuration version of the component.
     #[arg(short, long, default_value_t = 1)]
-    version: u64,
+    pub version: u64,
     /// The component to configure (e.g., 'com.system76.CosmicComp').
     #[arg(short, long, required_unless_present = "file")]
-    component: Option<String>,
+    pub component: Option<String>,
     /// The specific configuration entry to modify (e.g., 'autotile').
     #[arg(short, long, required_unless_present = "file")]
-    entry: Option<String>,
+    pub entry: Option<String>,
     /// The XDG directory to use (e.g., 'config', 'cache', 'data').
     #[arg(short, long, default_value = "config")]
-    xdg_dir: String,
+    pub xdg_dir: String,
     /// Direct path to the configuration file.
     #[arg(short, long, required_unless_present_all = &["component", "entry"])]
-    file: Option<PathBuf>,
+    pub file: Option<PathBuf>,
 }
 
 impl Command for DeleteCommand {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,9 +1,9 @@
-mod apply;
-mod backup;
-mod delete;
-mod read;
-mod reset;
-mod write;
+pub mod apply;
+pub mod backup;
+pub mod delete;
+pub mod read;
+pub mod reset;
+pub mod write;
 
 use crate::commands::{
     apply::ApplyCommand, backup::BackupCommand, delete::DeleteCommand, read::ReadCommand,

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -9,19 +9,19 @@ use std::{io::Error, path::PathBuf};
 pub struct ReadCommand {
     /// The configuration version of the component.
     #[arg(short, long, default_value_t = 1)]
-    version: u64,
+    pub version: u64,
     /// The component to configure (e.g., 'com.system76.CosmicComp').
     #[arg(short, long, required_unless_present = "file")]
-    component: Option<String>,
+    pub component: Option<String>,
     /// The specific configuration entry to modify (e.g., 'autotile').
     #[arg(short, long, required_unless_present = "file")]
-    entry: Option<String>,
+    pub entry: Option<String>,
     /// The XDG directory to use (e.g., 'config', 'cache', 'data').
     #[arg(short, long, default_value = "config")]
-    xdg_dir: String,
+    pub xdg_dir: String,
     /// Direct path to the configuration file.
     #[arg(short, long, required_unless_present_all = &["component", "entry"])]
-    file: Option<PathBuf>,
+    pub file: Option<PathBuf>,
 }
 
 impl Command for ReadCommand {

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -13,16 +13,16 @@ use walkdir::WalkDir;
 pub struct ResetCommand {
     /// Skip confirmation prompt.
     #[arg(short, long)]
-    force: bool,
+    pub force: bool,
     /// Show which entries are being deleted.
     #[arg(short, long)]
-    verbose: bool,
+    pub verbose: bool,
     /// Patterns to exclude from reset (comma-separated).
     #[arg(long)]
-    exclude: Option<String>,
+    pub exclude: Option<String>,
     /// The XDG directories to backup (comma-separated) (e.g., 'config,cache,data').
     #[arg(short, long, value_delimiter = ',', default_value = "config,state")]
-    xdg_dirs: Vec<String>,
+    pub xdg_dirs: Vec<String>,
 }
 
 impl Command for ResetCommand {

--- a/src/commands/write.rs
+++ b/src/commands/write.rs
@@ -9,21 +9,21 @@ use std::{io::Error, path::PathBuf};
 pub struct WriteCommand {
     /// The configuration version of the component.
     #[arg(short, long, default_value_t = 1)]
-    version: u64,
+    pub version: u64,
     /// The component to configure (e.g., 'com.system76.CosmicComp').
     #[arg(short, long, required_unless_present = "file")]
-    component: Option<String>,
+    pub component: Option<String>,
     /// The specific configuration entry to modify (e.g., 'autotile').
     #[arg(short, long, required_unless_present = "file")]
-    entry: Option<String>,
+    pub entry: Option<String>,
     /// The value to assign to the configuration entry. (e.g., 'true').
-    value: String,
+    pub value: String,
     /// The XDG directory to use (e.g., 'config', 'cache', 'data').
     #[arg(short, long, default_value = "config")]
-    xdg_dir: String,
+    pub xdg_dir: String,
     /// Direct path to the configuration file.
     #[arg(long, required_unless_present_all = &["component", "entry"])]
-    file: Option<PathBuf>,
+    pub file: Option<PathBuf>,
 }
 
 impl Command for WriteCommand {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,0 +1,306 @@
+use crate::commands::{
+    apply::ApplyCommand, backup::BackupCommand, delete::DeleteCommand, read::ReadCommand,
+    reset::ResetCommand, write::WriteCommand, Command,
+};
+use inquire::{MultiSelect, Select, Text};
+use std::{
+    io::{Error, ErrorKind},
+    path::PathBuf,
+};
+
+const XDG_DIRECTORIES: [&str; 5] = ["cache", "config", "data", "runtime", "state"];
+
+pub fn run_interactive_mode() -> Result<(), Error> {
+    let operation = Select::new(
+        "What would you like to do?",
+        vec!["Write", "Read", "Delete", "Apply", "Backup", "Reset"],
+    )
+    .prompt()
+    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    match operation {
+        "Write" => interactive_write()?,
+        "Read" => interactive_read()?,
+        "Delete" => interactive_delete()?,
+        "Apply" => interactive_apply()?,
+        "Backup" => interactive_backup()?,
+        "Reset" => interactive_reset()?,
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn interactive_write() -> Result<(), Error> {
+    let file_or_component = Select::new(
+        "Would you like to write to a file or a component?",
+        vec!["Component", "File"],
+    )
+    .prompt()
+    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    if file_or_component == "File" {
+        let file = Text::new("File path:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let value = Text::new("Value:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+
+        let cmd = WriteCommand {
+            version: 1,
+            component: None,
+            entry: None,
+            value,
+            xdg_dir: "config".to_string(),
+            file: Some(PathBuf::from(file)),
+        };
+
+        cmd.execute()
+    } else {
+        let component = Text::new("Component:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let entry = Text::new("Entry:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let version = Text::new("Version:")
+            .with_default("1")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?
+            .parse::<u64>()
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("Invalid version number: {}", e),
+                )
+            })?;
+        let xdg_dir = Select::new("XDG Directory:", XDG_DIRECTORIES.to_vec())
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+            .to_string();
+        let value = Text::new("Value:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+
+        let cmd = WriteCommand {
+            version,
+            component: Some(component),
+            entry: Some(entry),
+            value,
+            xdg_dir,
+            file: None,
+        };
+
+        cmd.execute()
+    }
+}
+
+fn interactive_read() -> Result<(), Error> {
+    let file_or_component = Select::new(
+        "Would you like to read from a file or a component?",
+        vec!["Component", "File"],
+    )
+    .prompt()
+    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    if file_or_component == "File" {
+        let file = Text::new("File path:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+
+        let cmd = ReadCommand {
+            version: 1,
+            component: None,
+            entry: None,
+            xdg_dir: "config".to_string(),
+            file: Some(PathBuf::from(file)),
+        };
+
+        cmd.execute()
+    } else {
+        let component = Text::new("Component:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let entry = Text::new("Entry:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let version = Text::new("Version:")
+            .with_default("1")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?
+            .parse::<u64>()
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("Invalid version number: {}", e),
+                )
+            })?;
+        let xdg_dir = Select::new("XDG Directory:", XDG_DIRECTORIES.to_vec())
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+            .to_string();
+
+        let cmd = ReadCommand {
+            version,
+            component: Some(component),
+            entry: Some(entry),
+            xdg_dir,
+            file: None,
+        };
+
+        cmd.execute()
+    }
+}
+
+fn interactive_delete() -> Result<(), Error> {
+    let file_or_component = Select::new(
+        "Would you like to delete a file or a component?",
+        vec!["Component", "File"],
+    )
+    .prompt()
+    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    if file_or_component == "File" {
+        let file = Text::new("File path:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+
+        let cmd = DeleteCommand {
+            version: 1,
+            component: None,
+            entry: None,
+            xdg_dir: "config".to_string(),
+            file: Some(PathBuf::from(file)),
+        };
+
+        cmd.execute()
+    } else {
+        let component = Text::new("Component:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let entry = Text::new("Entry:")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+        let version = Text::new("Version:")
+            .with_default("1")
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?
+            .parse::<u64>()
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("Invalid version number: {}", e),
+                )
+            })?;
+        let xdg_dir = Select::new("XDG Directory:", XDG_DIRECTORIES.to_vec())
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+            .to_string();
+
+        let cmd = DeleteCommand {
+            version,
+            component: Some(component),
+            entry: Some(entry),
+            xdg_dir,
+            file: None,
+        };
+
+        cmd.execute()
+    }
+}
+
+fn interactive_apply() -> Result<(), Error> {
+    let file = Text::new("Configuration file path:")
+        .prompt()
+        .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+    let verbose = Select::new("Verbose output?", vec!["Yes", "No"])
+        .prompt()
+        .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+        == "Yes";
+
+    let cmd = ApplyCommand {
+        file: PathBuf::from(file),
+        verbose,
+    };
+
+    cmd.execute()
+}
+
+fn interactive_backup() -> Result<(), Error> {
+    let file = Text::new("Output file path:")
+        .prompt()
+        .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+
+    let verbose = Select::new("Verbose output?", vec!["Yes", "No"])
+        .prompt()
+        .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+        == "Yes";
+
+    let selected_dirs = MultiSelect::new(
+        "Select XDG directories to backup:",
+        XDG_DIRECTORIES.to_vec(),
+    )
+    .prompt()
+    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    if selected_dirs.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "At least one XDG directory must be selected",
+        ));
+    }
+
+    let xdg_dirs: Vec<String> = selected_dirs.into_iter().map(String::from).collect();
+
+    let cmd = BackupCommand {
+        file: PathBuf::from(file),
+        verbose,
+        xdg_dirs,
+        format: None, // Will be auto-detected from file extension
+    };
+
+    cmd.execute()
+}
+
+fn interactive_reset() -> Result<(), Error> {
+    let exclude = Text::new("Patterns to exclude (comma-separated, leave empty for none):")
+        .prompt()
+        .map_err(|e| Error::new(ErrorKind::Other, format!("Input error: {}", e)))?;
+
+    let verbose = Select::new("Show verbose output?", vec!["Yes", "No"])
+        .prompt()
+        .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+        == "Yes";
+
+    let exclude_option = if exclude.trim().is_empty() {
+        None
+    } else {
+        Some(exclude)
+    };
+
+    let selected_dirs =
+        MultiSelect::new("Select XDG directories to reset:", XDG_DIRECTORIES.to_vec())
+            .prompt()
+            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    if selected_dirs.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "At least one XDG directory must be selected",
+        ));
+    }
+
+    let xdg_dirs: Vec<String> = selected_dirs.into_iter().map(String::from).collect();
+
+    // In interactive mode, we still want confirmation
+    // but we'll handle it through the ResetCommand's own prompt
+    let cmd = ResetCommand {
+        force: false, // Let the reset command handle confirmation
+        verbose,
+        exclude: exclude_option,
+        xdg_dirs,
+    };
+
+    cmd.execute()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
 mod commands;
 mod config;
 mod formats;
+mod interactive;
 mod schema;
 #[cfg(test)]
 mod tests;
 mod utils;
 
-use crate::commands::Commands;
+use crate::{commands::Commands, interactive::run_interactive_mode};
 use clap::Parser;
 
 /// CLI for COSMIC Desktop configuration management
@@ -15,13 +16,18 @@ use clap::Parser;
 #[command(propagate_version = true)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 fn main() {
     let cli = Cli::parse();
 
-    if let Err(e) = cli.command.execute() {
+    let result = match cli.command {
+        Some(cmd) => cmd.execute(),
+        None => run_interactive_mode(),
+    };
+
+    if let Err(e) = result {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }


### PR DESCRIPTION
Add an interactive TUI mode that's triggered when cosmic-ctl is invoked without arguments. This implements user-friendly menu-based navigation for all operations (write, read, delete, apply, backup, reset) using the inquire crate for interactive prompts.

The interactive mode provides:
- Operation type selection via dropdown menus
- Context-specific parameter inputs
- Standardized XDG directory selection
- Proper validation and error handling
- Consistent user experience across all commands